### PR TITLE
fix:  prettier only formats JS files

### DIFF
--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @applint/prettier-config
+
+## 1.0.0
+
+- feat: init

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,0 +1,21 @@
+# @applint/prettier-config
+
+阿里巴巴大淘宝前端 Prettier 可共享配置。
+
+## 快速开始
+
+### 安装
+
+```shell
+npm i @applint/prettier-config -D
+```
+
+### 使用
+
+在项目根目录创建 `.prettier.js` 并加入以下配置：
+
+```js
+const { config } = require('@applint/prettier-config');
+
+module.exports = config;  
+```

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@applint/prettier-config",
+  "version": "1.0.0",
+  "description": "阿里巴巴大淘宝前端 Prettier 可共享配置。",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apptools-lab/applint"
+  },
+  "bugs": {
+    "url": "https://github.com/apptools-lab/applint/issues"
+  },
+  "homepage": "https://github.com/apptools-lab/applint",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc",
+    "watch": "npm run clean && tsc -w",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/prettier": "^2.4.3",
+    "prettier": "^2.5.1",
+    "typescript": "^4.4.4"
+  },
+  "peerDependencies": {
+    "prettier": ">=2.0.0"
+  }
+}

--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -1,0 +1,9 @@
+import type { Options } from 'prettier';
+
+export const config: Options = {
+  printWidth: 120,
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+};

--- a/packages/prettier-config/tsconfig.json
+++ b/packages/prettier-config/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @applint/spec
 
+## 1.0.1
+
+- feat: add `@applint/prettier-config`
+
 ## 1.0.0
 
 - refactor: transform language from JS to TS

--- a/packages/spec/__tests__/getPrettierConfig.spec.ts
+++ b/packages/spec/__tests__/getPrettierConfig.spec.ts
@@ -41,6 +41,6 @@ describe('getPrettierConfig API', () => {
 async function getPrettierResult(rule: RuleKey) {
   const prettierConfig = getPrettierConfig(rule);
   const source = await fs.readFile(path.join(testFixturesDir, 'prettier/index.js'), 'utf-8');
-  const result = await prettier.check(source, prettierConfig);
+  const result = await prettier.check(source, { ...prettierConfig, parser: 'babel' });
   return result;
 }

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@applint/commitlint-config": "^1.0.0",
     "@applint/eslint-config": "^1.0.0",
+    "@applint/prettier-config": "^1.0.0",
     "@applint/stylelint-config": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "deepmerge": "^4.2.2",

--- a/packages/spec/src/eslint/common-ts.ts
+++ b/packages/spec/src/eslint/common-ts.ts
@@ -1,7 +1,7 @@
 import type { Linter } from 'eslint';
 
-const commonESLintTSConfig: Linter.Config = {
+const commonTypeScriptESLintConfig: Linter.Config = {
   extends: ['@applint/eslint-config/typescript'],
 };
 
-export default commonESLintTSConfig;
+export default commonTypeScriptESLintConfig;

--- a/packages/spec/src/eslint/common-ts.ts
+++ b/packages/spec/src/eslint/common-ts.ts
@@ -1,9 +1,7 @@
 import type { Linter } from 'eslint';
 
-const commonTypeScriptESLintConfig: Linter.Config = {
-  extends: [
-    '@applint/eslint-config/typescript',
-  ],
+const commonESLintTSConfig: Linter.Config = {
+  extends: ['@applint/eslint-config/typescript'],
 };
 
-export default commonTypeScriptESLintConfig;
+export default commonESLintTSConfig;

--- a/packages/spec/src/eslint/index.ts
+++ b/packages/spec/src/eslint/index.ts
@@ -1,15 +1,15 @@
 import commonESLintConfig from './common';
-import commonESLintTSConfig from './common-ts';
+import commonTypeScriptESLintConfig from './common-ts';
 import raxESLintConfig from './rax';
-import raxESLintTSConfig from './rax-ts';
+import raxTypeScriptESLintConfig from './rax-ts';
 import reactESLintConfig from './react';
-import reactESLintTSConfig from './react-ts';
+import reactTypeScriptESLintConfig from './react-ts';
 
 export default {
   common: commonESLintConfig,
-  'common-ts': commonESLintTSConfig,
+  'common-ts': commonTypeScriptESLintConfig,
   rax: raxESLintConfig,
-  'rax-ts': raxESLintTSConfig,
+  'rax-ts': raxTypeScriptESLintConfig,
   react: reactESLintConfig,
-  'react-ts': reactESLintTSConfig,
+  'react-ts': reactTypeScriptESLintConfig,
 };

--- a/packages/spec/src/eslint/index.ts
+++ b/packages/spec/src/eslint/index.ts
@@ -1,0 +1,15 @@
+import commonESLintConfig from './common';
+import commonESLintTSConfig from './common-ts';
+import raxESLintConfig from './rax';
+import raxESLintTSConfig from './rax-ts';
+import reactESLintConfig from './react';
+import reactESLintTSConfig from './react-ts';
+
+export default {
+  common: commonESLintConfig,
+  'common-ts': commonESLintTSConfig,
+  rax: raxESLintConfig,
+  'rax-ts': raxESLintTSConfig,
+  react: reactESLintConfig,
+  'react-ts': reactESLintTSConfig,
+};

--- a/packages/spec/src/eslint/react-ts.ts
+++ b/packages/spec/src/eslint/react-ts.ts
@@ -1,7 +1,7 @@
 import type { Linter } from 'eslint';
 
-const reactESLintTSConfig: Linter.Config = {
+const reactTypeScriptESLintConfig: Linter.Config = {
   extends: ['@applint/eslint-config/typescript/react'],
 };
 
-export default reactESLintTSConfig;
+export default reactTypeScriptESLintConfig;

--- a/packages/spec/src/eslint/react-ts.ts
+++ b/packages/spec/src/eslint/react-ts.ts
@@ -1,9 +1,7 @@
 import type { Linter } from 'eslint';
 
-const reactESLintConfig: Linter.Config = {
-  extends: [
-    '@applint/eslint-config/typescript/react',
-  ],
+const reactESLintTSConfig: Linter.Config = {
+  extends: ['@applint/eslint-config/typescript/react'],
 };
 
-export default reactESLintConfig;
+export default reactESLintTSConfig;

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -1,6 +1,8 @@
-import path from 'path';
-import requireAll from 'require-all';
 import deepmerge from 'deepmerge';
+import eslintConfig from './eslint';
+import stylelintConfig from './stylelint';
+import prettierConfig from './prettier';
+import commitlintConfig from './commitlint';
 import type { Linter } from 'eslint';
 import type { UserConfig as CommitlintUserConfig } from '@commitlint/types';
 import type { Config as StylelintConfig } from 'stylelint';
@@ -10,35 +12,29 @@ export type RuleKey = 'common' | 'common-ts' | 'react' | 'react-ts' | 'rax' | 'r
 
 // ESLint
 export function getESLintConfig(rule: RuleKey, userConfig: Linter.Config = {}): Linter.Config {
-  const eslint = requireAll({
-    dirname: path.resolve(__dirname, 'eslint'),
-  });
-  return deepmerge(eslint[rule]?.default || {}, userConfig);
+  return deepmerge(eslintConfig[rule] || {}, userConfig);
 }
 
 // stylelint
 // Note: rule param is to compatible with @iceworks/spec
-export function getStylelintConfig(rule: RuleKey, userConfig: StylelintConfig = {}): StylelintConfig {
-  const stylelint = requireAll({
-    dirname: path.resolve(__dirname, 'stylelint'),
-  });
-  return deepmerge(stylelint.index.default, userConfig);
+export function getStylelintConfig(
+  rule: RuleKey,
+  userConfig: StylelintConfig = {},
+): StylelintConfig {
+  return deepmerge(stylelintConfig, userConfig);
 }
 
 // commitlint
 // Note: rule param is to compatible with @iceworks/spec
-export function getCommitlintConfig(rule: RuleKey, userConfig: CommitlintUserConfig = {}): CommitlintUserConfig {
-  const commitlint = requireAll({
-    dirname: path.resolve(__dirname, 'commitlint'),
-  });
-  return deepmerge(commitlint.index.default, userConfig);
+export function getCommitlintConfig(
+  rule: RuleKey,
+  userConfig: CommitlintUserConfig = {},
+): CommitlintUserConfig {
+  return deepmerge(commitlintConfig, userConfig);
 }
 
 // prettier
 // Note: rule param is to compatible with @iceworks/spec
 export function getPrettierConfig(rule: RuleKey, userConfig: PrettierConfig = {}): PrettierConfig {
-  const prettier = requireAll({
-    dirname: path.resolve(__dirname, 'prettier'),
-  });
-  return deepmerge(prettier.index.default, userConfig);
+  return deepmerge(prettierConfig, userConfig);
 }

--- a/packages/spec/src/prettier/index.ts
+++ b/packages/spec/src/prettier/index.ts
@@ -1,12 +1,3 @@
-import type { Options } from 'prettier';
+import { config } from '@applint/prettier-config';
 
-const prettierConfig: Options = {
-  printWidth: 120,
-  tabWidth: 2,
-  semi: true,
-  singleQuote: true,
-  trailingComma: 'all',
-  parser: 'babel',
-};
-
-export default prettierConfig;
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   // https://www.typescriptlang.org/docs/handbook/project-references.html#overall-structure
   "files": [],
   "references": [
+    { "path": "packages/prettier-config" },
     { "path": "packages/projectlint" },
     { "path": "packages/spec" },
     { "path": "packages/applint" },


### PR DESCRIPTION
- Fix: 修复 prettier 只能对 JS 文件进行格式化，原因是在配置中指定了 parser
- Feat: 新增 @applint/prettier-config npm 包