### PR TITLE
Fix: can not find eslint-config in doctor

### DIFF
--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.2
 
 - fix: @typescript-eslint/parser dependency is lost
+- fix: can't find `@applint/eslint-config` in `@appworks/doctor`
 
 ## 1.0.1
 

--- a/packages/spec/src/eslint/common-ts.ts
+++ b/packages/spec/src/eslint/common-ts.ts
@@ -1,7 +1,10 @@
 import type { Linter } from 'eslint';
 
 const commonTypeScriptESLintConfig: Linter.Config = {
-  extends: ['@applint/eslint-config/typescript'],
+  extends: [
+    // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
+    require.resolve('@applint/eslint-config/typescript'),
+  ],
 };
 
 export default commonTypeScriptESLintConfig;

--- a/packages/spec/src/eslint/common.ts
+++ b/packages/spec/src/eslint/common.ts
@@ -2,7 +2,8 @@ import type { Linter } from 'eslint';
 
 const commonESLintConfig: Linter.Config = {
   extends: [
-    '@applint/eslint-config',
+    // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
+    require.resolve('@applint/eslint-config'),
   ],
 };
 

--- a/packages/spec/src/eslint/rax-ts.ts
+++ b/packages/spec/src/eslint/rax-ts.ts
@@ -2,6 +2,7 @@ import getRaxESLintConfig from './getRaxESLintConfig';
 
 export default getRaxESLintConfig({
   extends: [
-    '@applint/eslint-config/typescript/rax',
+    // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
+    require.resolve('@applint/eslint-config/typescript/rax'),
   ],
 });

--- a/packages/spec/src/eslint/rax.ts
+++ b/packages/spec/src/eslint/rax.ts
@@ -2,6 +2,7 @@ import getRaxESLintConfig from './getRaxESLintConfig';
 
 export default getRaxESLintConfig({
   extends: [
-    '@applint/eslint-config/rax',
+    // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
+    require.resolve('@applint/eslint-config/rax'),
   ],
 });

--- a/packages/spec/src/eslint/react-ts.ts
+++ b/packages/spec/src/eslint/react-ts.ts
@@ -1,7 +1,10 @@
 import type { Linter } from 'eslint';
 
 const reactTypeScriptESLintConfig: Linter.Config = {
-  extends: ['@applint/eslint-config/typescript/react'],
+  extends: [
+    // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
+    require.resolve('@applint/eslint-config/typescript/react'),
+  ],
 };
 
 export default reactTypeScriptESLintConfig;

--- a/packages/spec/src/eslint/react.ts
+++ b/packages/spec/src/eslint/react.ts
@@ -2,7 +2,8 @@ import type { Linter } from 'eslint';
 
 const reactESLintConfig: Linter.Config = {
   extends: [
-    '@applint/eslint-config/react',
+    // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
+    require.resolve('@applint/eslint-config/react'),
   ],
 };
 


### PR DESCRIPTION
修复在 `@appworks/doctor` 中无法调用 @applint/spec 获取 eslint 规则的问题