### PR TITLE
fix: get ESLint warning when use react component

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.2
+
+- fix: get ESLint warning when react variables(e.g.: component) were unused
+
 ## 1.0.1
 
 - docs: add JavaScript、TypeScript、React rules

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@applint/eslint-config",
   "description": "阿里巴巴大淘宝前端 ESLint 可共享配置。",
-  "version": "1.0.2-beta.0",
+  "version": "1.0.2",
   "main": "index.js",
   "license": "MIT",
   "keywords": [

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@applint/eslint-config",
   "description": "阿里巴巴大淘宝前端 ESLint 可共享配置。",
-  "version": "1.0.1",
+  "version": "1.0.2-beta.0",
   "main": "index.js",
   "license": "MIT",
   "keywords": [

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -6,10 +6,10 @@ module.exports = {
      *  React 规则
      * @link https://github.com/yannickcr/eslint-plugin-react
      */
-    // 防止 React 被标记为未使用
+    // 对 no-unused-vars 规则的补充，防止 React 被标记为未使用
     'react/jsx-uses-react': 'error',
 
-    // 防止 React 变量被标记为未使用
+    // 对 no-unused-vars 规则的补充，防止 React 变量被标记为未使用
     'react/jsx-uses-vars': 'error',
 
     // JSX 语法使用两个空格缩进

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -6,6 +6,12 @@ module.exports = {
      *  React 规则
      * @link https://github.com/yannickcr/eslint-plugin-react
      */
+    // 防止 React 被标记为未使用
+    'react/jsx-uses-react': 'error',
+
+    // 防止 React 变量被标记为未使用
+    'react/jsx-uses-vars': 'error',
+
     // JSX 语法使用两个空格缩进
     'react/jsx-indent': ['error', 2],
     'react/jsx-indent-props': ['error', 2],

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @applint/spec
 
+## 1.1.1
+
+- fix: missing package `eslint-plugin-rax-compile-time-miniapp`
+
 ## 1.1.0
 
 - feat: support lint vue files

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applint/spec",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "在 ICE、Rax、React 项目中更简单接入 ESLint(support TypeScript) / Stylelint / Prettier / Commitlint 规则。",
   "main": "dist/index.js",
   "files": [
@@ -37,6 +37,7 @@
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-jsx-plus": "^0.1.0",
+    "eslint-plugin-rax-compile-time-miniapp": "^1.0.0",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vue": "^8.4.1",


### PR DESCRIPTION
- fix: get ESLint warning when react variables(e.g.: component) were unused
- fix: missing package `eslint-plugin-rax-compile-time-miniapp`