### PR TITLE
fix: not special tsconfigRootDir config

### DIFF
--- a/packages/applint/CHANGELOG.md
+++ b/packages/applint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @applint/applint
 
+## 1.1.1
+
+- fix: not specify `parserOptions.tsconfigRootDir` in eslint config
+
 ## 1.1.0
 
 - feat: support scan specified rule in `.eslintrc.js`

--- a/packages/applint/__tests__/__fixtures__/tsconfig.json
+++ b/packages/applint/__tests__/__fixtures__/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "build",
+    "module": "esnext",
+    "target": "es6",
+    "jsx": "preserve",
+    "jsxFactory": "createElement",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "lib": ["es6", "dom"],
+    "sourceMap": true,
+    "allowJs": true,
+    "rootDir": "./",
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": false,
+    "importHelpers": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "types": ["node", "jest"],
+    "paths": {
+      "@/*": ["./src/*"],
+      "rax-app": [".rax/index.ts"]
+    }
+  },
+  "include": ["src", ".rax"],
+  "exclude": ["node_modules", "build", "public"]
+}

--- a/packages/applint/package.json
+++ b/packages/applint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applint/applint",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "提供 ESLint、Stylelint 检查和修复的 Node API。",
   "main": "dist/index.js",
   "files": [

--- a/packages/applint/src/ESLint.ts
+++ b/packages/applint/src/ESLint.ts
@@ -20,6 +20,9 @@ export class ESLint extends Linter<ESLintBase.LintResult[]> {
     // get rule key in `.eslintrc.js`
     this.ruleKey = (this.getRuleKeyInConfigFile(configFilename, apiName) || this.ruleKey) as RuleKey;
     this.config = getESLintConfig(this.ruleKey) as ESLinter.Config;
+    // specify `parserOptions.tsconfigRootDir`
+    this.config.parserOptions = this.config.parserOptions || {};
+    this.config.parserOptions = { ...this.config.parserOptions, tsconfigRootDir: this.directory };
     this.targetFiles = this.getTargetFiles(ignoreFilename, supportiveFileRegExp);
   }
 


### PR DESCRIPTION
没有指定 `parserOptions.tsconfigRootDir`，导致在使用 ESLint 扫描 TS 文件的时候，未找到正确的 tsconfig.json 路径（https://github.com/apptools-lab/AppLint/blob/36b45c681f068f9daf0a6f45bc7b44e79a64f848/packages/eslint-config/rules/typescript.js#L19）