### PR TITLE
chore: set ts-ban-types rule to warn

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.6
+
+- fix: `@typescript-eslint/ban-types` rule can not be auto fixed in some cases
+
 ## 1.1.5
 
 - fix: add rule `jsx-closing-bracket-location` option `line-aligned` to fix jsx code can't be auto fix

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@applint/eslint-config",
   "description": "阿里巴巴大淘宝前端 ESLint 可共享配置。",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "index.js",
   "license": "MIT",
   "keywords": [

--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -132,7 +132,7 @@ module.exports = {
     // 1. 不使用大写的原始类型，应该使用小写的类型
     // 2. 对于对象类型，应使用 Record<string, unknown>，而不是 object
     // 3. 对于函数类型，应使用入参和返回值被标注的具体类型
-    '@typescript-eslint/ban-types': 'error',
+    '@typescript-eslint/ban-types': 'warn',
 
     // 不允许不必要的类型标注，但允许类的属性成员进行额外标注
     '@typescript-eslint/no-inferrable-types': 'error',


### PR DESCRIPTION
`@typescript-eslint/ban-types` 规则在部分情况下不能自动修复（虽然官方文档上面写着可以自动修复）

这种情况下可以自动修复：
```diff
- const curly1: String = 'xxx';
+ const curly1: string = 'xxx';

- const num: Number = 1;
+ const num: number = 1;
```

这种情况不可以自动修复：
```ts
const curly1: {} = 1;
const curly2: {} = { a: 'string' };
```

`@typescript-eslint/ban-types` 规则官方文档：https://typescript-eslint.io/rules/ban-types/