### PR TITLE
chore: remove some peerDependencies

### DIFF
--- a/packages/commitlint-config/CHANGELOG.md
+++ b/packages/commitlint-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @applint/commitlint-config
 
+## 1.0.2
+
+- chore: remove peerDependencies
+
 ## 0.1.0
 
 - feat: init commitlint config.

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applint/commitlint-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "阿里巴巴大淘宝前端 Commitlint 可共享配置。",
   "main": "index.js",
   "repository": {
@@ -18,9 +18,5 @@
   "license": "MIT",
   "dependencies": {
     "conventional-changelog-conventionalcommits": "^4.6.1"
-  },
-  "peerDependencies": {
-    "@commitlint/cli": ">=13.0.0",
-    "husky": ">=7.0.0"
   }
 }

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @applint/prettier-config
 
+## 1.0.1
+
+- chore: remove peerDependencies
+
 ## 1.0.0
 
 - feat: init

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applint/prettier-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "阿里巴巴大淘宝前端 Prettier 可共享配置。",
   "main": "dist/index.js",
   "files": [
@@ -25,8 +25,5 @@
     "@types/prettier": "^2.4.3",
     "prettier": "^2.5.1",
     "typescript": "^4.4.4"
-  },
-  "peerDependencies": {
-    "prettier": ">=2.0.0"
   }
 }

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @applint/spec
 
+## 1.2.2
+
+- chore: remove `@commitlint/cli` and `prettier` peerDependencies
+
 ## 1.2.1
 
 - feat: add global variable `weex` to vue config

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applint/spec",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "在 ICE、Rax、React 项目中更简单接入 ESLint(support TypeScript) / Stylelint / Prettier / Commitlint 规则。",
   "main": "dist/index.js",
   "files": [
@@ -67,9 +67,7 @@
     "typescript": "^4.4.4"
   },
   "peerDependencies": {
-    "@commitlint/cli": ">=13.0.0",
     "eslint": ">=6.8.0",
-    "prettier": ">=2.0.0",
     "stylelint": ">=14.0.0"
   },
   "engines": {


### PR DESCRIPTION
移除   peerDependcies  `@commitlint/cli` 和 `prettier`，因为这两个 npm 包不是必须的安装的，否则会在依赖安装的时候会有 peerDependencies 缺失的日志出现。