### PR TITLE
fix: disable react/self-closing-comp in rax

### DIFF
--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @applint/spec
 
+## 1.2.2
+
+- fix: disable `react/self-closing-comp` rule in rax because the self closing comp will be error in some cases
+
 ## 1.2.1
 
 - feat: add global variable `weex` to vue config

--- a/packages/spec/__tests__/getESLintConfig.spec.ts
+++ b/packages/spec/__tests__/getESLintConfig.spec.ts
@@ -41,19 +41,19 @@ describe('getESLintConfig API', () => {
   test('rax', async () => {
     const results = await getESLintResults('rax', [path.join(testFixturesDir, 'eslint/index.jsx')]);
     expect(results.length).toBe(1);
-    expect(results[0].messages.length).toBe(3);
+    expect(results[0].messages.length).toBe(2);
   });
 
   test('rax-ts', async () => {
     const results = await getESLintResults('rax-ts', [path.join(testFixturesDir, 'eslint/index.tsx')]);
     expect(results.length).toBe(1);
-    expect(results[0].messages.length).toBe(5);
+    expect(results[0].messages.length).toBe(4);
   });
 
   test('rax-ts-strict', async () => {
     const results = await getESLintResults('rax-ts-strict', [path.join(testFixturesDir, 'eslint/index.tsx')]);
     expect(results.length).toBe(1);
-    expect(results[0].messages.length).toBe(7);
+    expect(results[0].messages.length).toBe(6);
   });
 });
 

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applint/spec",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "在 ICE、Rax、React 项目中更简单接入 ESLint(support TypeScript) / Stylelint / Prettier / Commitlint 规则。",
   "main": "dist/index.js",
   "files": [

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applint/spec",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "在 ICE、Rax、React 项目中更简单接入 ESLint(support TypeScript) / Stylelint / Prettier / Commitlint 规则。",
   "main": "dist/index.js",
   "files": [

--- a/packages/spec/src/eslint/rax-ts-strict.ts
+++ b/packages/spec/src/eslint/rax-ts-strict.ts
@@ -5,4 +5,7 @@ export default getRaxESLintConfig({
     // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
     require.resolve('@applint/eslint-config/typescript/rax-strict'),
   ],
+  rules: {
+    'react/self-closing-comp': 0,
+  },
 });

--- a/packages/spec/src/eslint/rax-ts.ts
+++ b/packages/spec/src/eslint/rax-ts.ts
@@ -5,4 +5,7 @@ export default getRaxESLintConfig({
     // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
     require.resolve('@applint/eslint-config/typescript/rax'),
   ],
+  rules: {
+    'react/self-closing-comp': 0,
+  },
 });

--- a/packages/spec/src/eslint/rax.ts
+++ b/packages/spec/src/eslint/rax.ts
@@ -5,4 +5,7 @@ export default getRaxESLintConfig({
     // if not use require.resolve(), the @applint/eslint-config can't be find in @appworks/doctor(call with Node API)
     require.resolve('@applint/eslint-config/rax'),
   ],
+  rules: {
+    'react/self-closing-comp': 0,
+  },
 });


### PR DESCRIPTION
rax 基础库中的 renderToString 方法没有支持 自闭合标签，对于这种情况，需要禁用掉 ` react/self-closing-comp` 这条规则避免格式化成自闭合标签。