### PR TITLE
remove @typescript-eslint/indent rule

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.1.8
+
+- fix: remove `@typescript-eslint/indent` rule. Ref: <https://github.com/typescript-eslint/typescript-eslint/issues/1824>
+
+## 1.1.7
+
 - fix: eslint 8 breaks `indent` rule when using decorators in params. Ref: <https://github.com/eslint/eslint/issues/15299#issuecomment-968099681>
 
 ## 1.1.6

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@applint/eslint-config",
   "description": "阿里巴巴大淘宝前端 ESLint 可共享配置。",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "main": "index.js",
   "license": "MIT",
   "keywords": [

--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -53,53 +53,6 @@ module.exports = {
     // interface 和 type 里的成员统一使用分号（;）进行分割，单行类型的最后一个元素不加分号
     '@typescript-eslint/member-delimiter-style': 'error',
 
-    // 缩进为2个空格
-    indent: 'off',
-    '@typescript-eslint/indent': [
-      'error',
-      2,
-      {
-        SwitchCase: 1,
-        VariableDeclarator: 1,
-        outerIIFEBody: 1,
-        FunctionDeclaration: {
-          parameters: 1,
-          body: 1,
-        },
-        FunctionExpression: {
-          parameters: 1,
-          body: 1,
-        },
-        CallExpression: {
-          arguments: 1,
-        },
-        ArrayExpression: 1,
-        ObjectExpression: 1,
-        ImportDeclaration: 1,
-        flatTernaryExpressions: false,
-        // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
-        ignoredNodes: [
-          'TemplateLiteral', // FIXME https://github.com/babel/babel-eslint/issues/799#issuecomment-568195009
-          'JSXElement',
-          'JSXElement > *',
-          'JSXAttribute',
-          'JSXIdentifier',
-          'JSXNamespacedName',
-          'JSXMemberExpression',
-          'JSXSpreadAttribute',
-          'JSXExpressionContainer',
-          'JSXOpeningElement',
-          'JSXClosingElement',
-          'JSXText',
-          'JSXEmptyExpression',
-          'JSXSpreadChild',
-          'PropertyDefinition',
-          'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
-        ],
-        ignoreComments: false,
-      },
-    ],
-
     // 强制使用分号
     semi: 'off',
     '@typescript-eslint/semi': 'error',


### PR DESCRIPTION
移除 `@typescript-eslint/indent` 规则，该规则在某些场景下有问题，并且作者说明不会修复，详见[链接]。(https://github.com/typescript-eslint/typescript-eslint/issues/1824)

去掉后，直接使用 eslint 的 indent 规则。