### PR TITLE
chore: remove react/no-unknown-property rule

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: `@typescript-eslint/keyword-spacing` rule will occur Unexpected space(s) before "{" in import type error. Ref: <https://github.com/typescript-eslint/typescript-eslint/issues/6063>
 - fix: `@typescript-eslint/no-inferrable-types` will be conflict with `typedef` rule
+- chore: remove `react/no-unknown-property` rule
 
 ## 1.1.8
 

--- a/packages/eslint-config/docs/React.md
+++ b/packages/eslint-config/docs/React.md
@@ -289,21 +289,7 @@ const AnotherHello = createReactClass({
 });
 ```
 
-### 2. DOM 属性
-
-**2.1 防止使用未知的 DOM 属性。eslint: [react/no-unknown-property](https://github.com/yannickcr/eslint-plugin-react/blob/e3d3525bf9d2ddbb312e31edc0837293e1b391f5/docs/rules/no-unknown-property.md)**
-
-在 JSX 中，所有的 DOM 属性和属性都应该使用 CAMELCASE，与标准的 DOM API 保持一致。
-
-```jsx
-// bad
-const Hello = <div class="hello">Hello World</div>;
-
-// good
-const Hello = <div className="hello">Hello World</div>;
-```
-
-### 3. Props
+### 2. Props
 
 **3.1 组件 props 值为 true 时，可以忽略其值。eslint: [react/jsx-boolean-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)**
 

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -55,9 +55,6 @@ module.exports = {
     // 组件 props 值为 true 时，可以忽略其值
     'react/jsx-boolean-value': 'error',
 
-    // 防止使用未知的 DOM 属性。在 JSX 中，所有的 DOM 属性和属性都应该使用 CAMELCASE，与标准的 DOM API 保持一致。
-    'react/no-unknown-property': 'error',
-
     /**
      * React Hooks 规则
      * @link https://www.npmjs.com/package/eslint-plugin-react-hooks


### PR DESCRIPTION
用户可能在 document.tsx 文件中编写原生标签和属性（比如 `<meta http-equiv="xx" />`），有可能会把正确属性给修改成错误的。

https://github.com/apptools-lab/AppLint/issues/49