### PR TITLE
fix: disable prefer-nullish-coalescing rule as it might be dangerous

### DIFF
--- a/packages/eslint-config/rules/typescript-strict.js
+++ b/packages/eslint-config/rules/typescript-strict.js
@@ -278,7 +278,7 @@ module.exports = {
     // UPDATE: TS 5.0 对枚举支持进一步增强了
     '@typescript-eslint/prefer-literal-enum-member': 'off',
     // 使用 ?? 而不是 ||
-    '@typescript-eslint/prefer-nullish-coalescing': ['warn'],
+    '@typescript-eslint/prefer-nullish-coalescing': ['off'],
     // 使用 ?. 而不是 &&
     '@typescript-eslint/prefer-optional-chain': ['warn'],
     // 为 reduce 方法传入显式的类型参数，因为通常 reduce 方法的初始值会是 [] 或者 {} 这种，没法推导出来结果类型

--- a/packages/spec/__tests__/getESLintConfig.spec.ts
+++ b/packages/spec/__tests__/getESLintConfig.spec.ts
@@ -20,7 +20,7 @@ describe('getESLintConfig API', () => {
 
   test('common-ts-strict', async () => {
     const results = await getESLintResults('common-ts-strict', [path.join(testFixturesDir, 'eslint/index.ts')]);
-    expect(results[0].messages.length).toBe(2);
+    expect(results[0].messages.length).toBe(1);
   });
 
   test('react', async () => {
@@ -36,7 +36,7 @@ describe('getESLintConfig API', () => {
   test('react-ts-strict', async () => {
     const results = await getESLintResults('react-ts-strict', [path.join(testFixturesDir, 'eslint/index.tsx')]);
     expect(results.length).toBe(1);
-    expect(results[0].messages.length).toBe(4);
+    expect(results[0].messages.length).toBe(3);
   });
 
   test('rax', async () => {
@@ -54,7 +54,7 @@ describe('getESLintConfig API', () => {
   test('rax-ts-strict', async () => {
     const results = await getESLintResults('rax-ts-strict', [path.join(testFixturesDir, 'eslint/index.tsx')]);
     expect(results.length).toBe(1);
-    expect(results[0].messages.length).toBe(3);
+    expect(results[0].messages.length).toBe(2);
   });
 });
 


### PR DESCRIPTION
`??` 替换为 `||` 的规则在我们团队内几个业务发现存在一定危险性，会进行破坏实际逻辑的自动修复行为。