### PR TITLE
fix: ci publish script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           version: yarn run version
           commit: 'chore: update versions'
           title: 'chore: update versions'
-          publish: yarn publish
+          publish: yarn run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Run `yarn publish` will not execute the changeset publish